### PR TITLE
Use html_url instead of url for repo href

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -158,7 +158,7 @@
 
         paragraph.appendChild(document.createTextNode("GitHub: "));
         var anchor = document.createElement("a");
-        anchor.setAttribute("href", repo.url);
+        anchor.setAttribute("href", repo.html_url);
         anchor.appendChild(document.createTextNode(repo.full_name));
         paragraph.appendChild(anchor)
         paragraph.appendChild(document.createElement("br"));


### PR DESCRIPTION
Which links to the "normal" repo page rather than the API, e.g.

```
"name": "docker-oracle-database-express-edition-11g",
"full_name": "UKHomeOffice/docker-oracle-database-express-edition-11g",
…
"html_url": "https://github.com/UKHomeOffice/docker-oracle-database-express-edition-11g",
"url": "https://api.github.com/repos/UKHomeOffice/docker-oracle-database-express-edition-11g",
```
